### PR TITLE
Provide the right QUERY_STRING

### DIFF
--- a/lib/nodephp.js
+++ b/lib/nodephp.js
@@ -406,7 +406,7 @@ function serveFpm(script_file, script_dir, request, response, params, options) {
 
     params = makeHeaders(request.headers, [
         ["SCRIPT_FILENAME",script_dir + '/' + script_file],
-        ["QUERY_STRING", request.url],
+        ["QUERY_STRING", url.parse(request.url).query],
         ["REQUEST_METHOD", request.method],
         ["SCRIPT_NAME", script_file],
         ["DOCUMENT_URI", script_file],
@@ -470,7 +470,7 @@ function createServer(opts, block) {
 
         // We simulate that the index page is is index.php if the requested
         // script was "/". 
-        var script_file = request.url == '/' ? '/index.php' :  request.url;
+        var script_file = request.url == '/' ? '/index.php' :  url.parse(request.url).pathname;
         var script_name = script_file.substr(1, script_file.length);
         
         // We only pass `pwd` as the second argument an we can run a server


### PR DESCRIPTION
Provide the right QUERY_STRING and filename for some.php?vars=1 GET requests

These 2  changes allow me to provide GET vars to PHP files that are correctly interpreted within a var_export($_GET). Onwards to figuring out $_POST vars.
